### PR TITLE
Be more conservative when handling <style> tags

### DIFF
--- a/html_archiver.py
+++ b/html_archiver.py
@@ -154,10 +154,14 @@ class HTMLArchiver:
             orig_css_string = style_tag.string
             css_string = self.archive_css(orig_css_string, base_url=base_url)
 
+            # If the CSS hasn't changed, we don't need to edit the HTML
+            if orig_css_string == css_string:
+                continue
+
             match = re.search(
-                r'<style(?P<attrs>[^>]+)>\s*?%s\s*?</style>' % (
-                    re.escape(orig_css_string)),
-                html_string
+                r'<style(?P<attrs>[^>]*)>\s*?%s\s*?</style>' % (
+                    re.escape(orig_css_string).strip()),
+                html_string,
             )
             assert match is not None, orig_css_string
             html_string = html_string.replace(

--- a/tests/expected/styles_inline.html
+++ b/tests/expected/styles_inline.html
@@ -1,0 +1,31 @@
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>This is a page with inline styles</title>
+
+  <!-- Inline scripts can appear in the <head> -->
+
+  <style>
+    p { color: purple; }
+    b { color: blue; }
+  </style>
+
+</head>
+
+<body>
+  <p>This is a page to test how html-archiver handles inline styles.</p>
+
+  <p>These inline styles do not refer to external resources, so they should be left unmodified.</p>
+
+  <!-- Or interspersed in the <body> -->
+
+  <style>
+    a { color: amber; }
+    p { color: pink; }
+    b { color: brown; }
+  </style>
+
+</body>
+
+</html>

--- a/tests/expected/styles_inline.html
+++ b/tests/expected/styles_inline.html
@@ -4,11 +4,13 @@
   <meta charset="utf-8">
   <title>This is a page with inline styles</title>
 
-  <!-- Inline scripts can appear in the <head> -->
-
   <style>
     p { color: purple; }
     b { color: blue; }
+  </style>
+
+  <style foo="bar">
+    a:hover { text-decoration: none; }
   </style>
 
 </head>
@@ -18,12 +20,16 @@
 
   <p>These inline styles do not refer to external resources, so they should be left unmodified.</p>
 
-  <!-- Or interspersed in the <body> -->
+  <p style="color: orange;">This text is orange.</p>
 
   <style>
     a { color: amber; }
     p { color: pink; }
     b { color: brown; }
+  </style>
+
+  <style bar="baz">
+    strong { font-size: 1.3em; }
   </style>
 
 </body>

--- a/tests/inputs/styles_inline.html
+++ b/tests/inputs/styles_inline.html
@@ -1,0 +1,31 @@
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>This is a page with inline styles</title>
+
+  <!-- Inline scripts can appear in the <head> -->
+
+  <style>
+    p { color: purple; }
+    b { color: blue; }
+  </style>
+
+</head>
+
+<body>
+  <p>This is a page to test how html-archiver handles inline styles.</p>
+
+  <p>These inline styles do not refer to external resources, so they should be left unmodified.</p>
+
+  <!-- Or interspersed in the <body> -->
+
+  <style>
+    a { color: amber; }
+    p { color: pink; }
+    b { color: brown; }
+  </style>
+
+</body>
+
+</html>

--- a/tests/inputs/styles_inline.html
+++ b/tests/inputs/styles_inline.html
@@ -4,11 +4,13 @@
   <meta charset="utf-8">
   <title>This is a page with inline styles</title>
 
-  <!-- Inline scripts can appear in the <head> -->
-
   <style>
     p { color: purple; }
     b { color: blue; }
+  </style>
+
+  <style foo="bar">
+    a:hover { text-decoration: none; }
   </style>
 
 </head>
@@ -18,12 +20,16 @@
 
   <p>These inline styles do not refer to external resources, so they should be left unmodified.</p>
 
-  <!-- Or interspersed in the <body> -->
+  <p style="color: orange;">This text is orange.</p>
 
   <style>
     a { color: amber; }
     p { color: pink; }
     b { color: brown; }
+  </style>
+
+  <style bar="baz">
+    strong { font-size: 1.3em; }
   </style>
 
 </body>


### PR DESCRIPTION
* Handle tags that don't any attributes
* Trim extra whitespace
* Only edit the `<style>` tag if it's changed

Plus some new test cases.

Resolves #4.